### PR TITLE
Fix legacy PHP 5.6 Docker build on current Docker/ARM hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,25 @@ FROM php:5.6-apache
 # Install the mysqli extension
 RUN docker-php-ext-install mysqli
 
+<<<<<<< HEAD
 # Update repo
 RUN apt-get update -y
 
 # Install mysql-client
 RUN apt-get install mysql-client -y
+=======
+# Update package sources for the archived Debian Stretch base image and
+# install the CLI tools needed during the image build.
+RUN set -eux; \
+  printf '%s\n' \
+    'deb [trusted=yes] http://archive.debian.org/debian stretch main' \
+    'deb [trusted=yes] http://archive.debian.org/debian-security stretch/updates main' \
+    > /etc/apt/sources.list; \
+  printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive; \
+  apt-get update -o Acquire::Check-Valid-Until=false; \
+  apt-get install -y --no-install-recommends curl default-mysql-client; \
+  rm -rf /var/lib/apt/lists/*
+>>>>>>> 00ae996 (Fix failing build on obsolite debian packages)
 
 # Install wp-cli as wp
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,6 @@ FROM php:5.6-apache
 # Install the mysqli extension
 RUN docker-php-ext-install mysqli
 
-<<<<<<< HEAD
-# Update repo
-RUN apt-get update -y
-
-# Install mysql-client
-RUN apt-get install mysql-client -y
-=======
 # Update package sources for the archived Debian Stretch base image and
 # install the CLI tools needed during the image build.
 RUN set -eux; \
@@ -22,7 +15,6 @@ RUN set -eux; \
   apt-get update -o Acquire::Check-Valid-Until=false; \
   apt-get install -y --no-install-recommends curl default-mysql-client; \
   rm -rf /var/lib/apt/lists/*
->>>>>>> 00ae996 (Fix failing build on obsolite debian packages)
 
 # Install wp-cli as wp
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.1'
-
 services:
 
     db:
+        # MySQL 5.7 is pulled as amd64 on Apple Silicon, so make that explicit.
+        platform: linux/amd64
         # mysql/mysql-server is less in size than mysql
         image: mysql/mysql-server:5.7
         restart: always


### PR DESCRIPTION
### This PR fixes the local WordPress Docker setup so it can still build and run with php:5.6-apache. #2 

## What changed

Updated the Docker image build to use Debian Stretch archive repositories instead of the removed default mirrors.
Disabled the expired package metadata check required for archived Stretch packages.
Installed curl and default-mysql-client in the same apt layer used during image setup.
Removed the obsolete Compose version field.
Pinned the MySQL 5.7 service to linux/amd64 so the setup works predictably on Apple Silicon / ARM hosts.
Why

The build was failing during apt-get update because Debian Stretch is end-of-life and its normal package URLs now return 404. On ARM machines, MySQL 5.7 also runs via amd64 emulation, so making that explicit avoids confusion during startup.

## Verification

docker compose build wordpress
docker compose up -d
Confirmed both containers start successfully
Confirmed MySQL reaches healthy
Confirmed WordPress is available on http://localhost:8080